### PR TITLE
Add theme toggle with light mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,9 +14,11 @@ import { CertificateGenerator } from './components/CertificateGenerator';
 import { AIConfigurationPanel } from './components/AIConfigurationPanel';
 import { useAuth } from './hooks/useAuth';
 import { modules as staticModules } from './data/modules';
+import { useTheme } from './hooks/useTheme';
 import { useModules } from './hooks/useModules';
 
 const AppContent: React.FC = () => {
+  useTheme();
   const { user, isLoading } = useAuth();
   const { modules } = useModules();
   const allModules = modules.length > 0 ? modules : staticModules;
@@ -26,7 +28,7 @@ const AppContent: React.FC = () => {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-100 dark:bg-gray-900 flex items-center justify-center text-gray-900 dark:text-gray-100">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-4 border-blue-600 border-t-transparent mx-auto mb-4"></div>
           <p className="text-gray-400">Cargando LÍNEA EDUCATRACK...</p>
@@ -70,7 +72,7 @@ const AppContent: React.FC = () => {
 
   if (showCertificate) {
     return (
-      <div className="min-h-screen bg-gray-900 p-4">
+      <div className="min-h-screen bg-gray-100 dark:bg-gray-900 p-4 text-gray-900 dark:text-gray-100">
         <CertificateGenerator
           certificate={showCertificate.certificate}
           module={showCertificate.module}
@@ -142,7 +144,7 @@ const AppContent: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-900">
+    <div className="min-h-screen bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
       <Navigation activeTab={activeTab} onTabChange={setActiveTab} />
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {renderContent()}

--- a/src/components/AITutor.tsx
+++ b/src/components/AITutor.tsx
@@ -220,7 +220,7 @@ export const AITutor: React.FC = () => {
             initial={{ opacity: 0, scale: 0.8, y: 100 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.8, y: 100 }}
-            className={`fixed bottom-6 right-6 bg-gray-800 rounded-lg shadow-2xl border border-gray-700 z-50 ${
+            className={`fixed bottom-6 right-6 bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 z-50 ${
               isMinimized ? 'w-80 h-16' : 'w-96 h-[600px]'
             } transition-all duration-300`}
           >

--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -54,7 +54,7 @@ export const AdminDashboard: React.FC = () => {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Admin Dashboard</h1>
-          <p className="text-gray-600">Monitor training progress and manage the platform</p>
+          <p className="text-gray-500 dark:text-gray-400">Monitor training progress and manage the platform</p>
         </div>
         <div className="flex items-center gap-2 px-3 py-2 bg-green-100 text-green-800 rounded-lg">
           <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
@@ -67,9 +67,9 @@ export const AdminDashboard: React.FC = () => {
         {stats.map((stat, index) => {
           const Icon = stat.icon;
           return (
-            <div key={index} className="bg-gray-800 p-6 rounded-xl shadow-sm border border-gray-700">
+            <div key={index} className="bg-white dark:bg-gray-800 p-6 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
               <div className="flex items-center justify-between mb-4">
-                <div className="p-2 bg-blue-900 rounded-lg">
+                <div className="p-2 bg-blue-100 dark:bg-blue-900 rounded-lg">
                   <Icon className="h-5 w-5 text-blue-600" />
                 </div>
                 <span className={`text-sm font-medium ${
@@ -79,8 +79,8 @@ export const AdminDashboard: React.FC = () => {
                 </span>
               </div>
               <div>
-                <p className="text-2xl font-bold text-gray-100">{stat.value}</p>
-                <p className="text-sm text-gray-400">{stat.title}</p>
+                <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">{stat.value}</p>
+                <p className="text-sm text-gray-500 dark:text-gray-400">{stat.title}</p>
               </div>
             </div>
           );
@@ -89,9 +89,9 @@ export const AdminDashboard: React.FC = () => {
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Recent Activities */}
-        <div className="bg-gray-800 p-6 rounded-xl shadow-sm border border-gray-700">
+        <div className="bg-white dark:bg-gray-800 p-6 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
           <div className="flex items-center justify-between mb-6">
-            <h2 className="text-lg font-semibold text-gray-100">Recent Activities</h2>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Recent Activities</h2>
             <button className="text-blue-600 hover:text-blue-700 text-sm font-medium">
               View All
             </button>
@@ -102,7 +102,7 @@ export const AdminDashboard: React.FC = () => {
               <div key={index} className="flex items-center justify-between p-3 hover:bg-gray-700 rounded-lg transition-colors">
                 <div className="flex-1">
                   <div className="flex items-center gap-2 mb-1">
-                    <span className="font-medium text-gray-100">{activity.user}</span>
+                    <span className="font-medium text-gray-900 dark:text-gray-100">{activity.user}</span>
                     <span className={`px-2 py-1 rounded-full text-xs font-medium ${
                       activity.action === 'Completed' 
                         ? 'bg-green-100 text-green-800'
@@ -113,12 +113,12 @@ export const AdminDashboard: React.FC = () => {
                       {activity.action}
                     </span>
                   </div>
-                  <p className="text-sm text-gray-400">{activity.module}</p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">{activity.module}</p>
                   <p className="text-xs text-gray-500">{activity.time}</p>
                 </div>
                 {activity.score && (
                   <div className="text-right">
-                    <p className="text-sm font-medium text-gray-100">{activity.score}%</p>
+                    <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{activity.score}%</p>
                   </div>
                 )}
               </div>
@@ -127,9 +127,9 @@ export const AdminDashboard: React.FC = () => {
         </div>
 
         {/* Department Progress */}
-        <div className="bg-gray-800 p-6 rounded-xl shadow-sm border border-gray-700">
+        <div className="bg-white dark:bg-gray-800 p-6 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
           <div className="flex items-center justify-between mb-6">
-            <h2 className="text-lg font-semibold text-gray-100">Department Progress</h2>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Department Progress</h2>
             <button className="text-blue-600 hover:text-blue-700 text-sm font-medium">
               Export Report
             </button>
@@ -139,8 +139,8 @@ export const AdminDashboard: React.FC = () => {
             {departmentProgress.map((dept, index) => (
               <div key={index} className="space-y-2">
                 <div className="flex items-center justify-between">
-                  <span className="font-medium text-gray-100">{dept.name}</span>
-                  <span className="text-sm text-gray-400">
+                  <span className="font-medium text-gray-900 dark:text-gray-100">{dept.name}</span>
+                  <span className="text-sm text-gray-500 dark:text-gray-400">
                     {dept.completed}/{dept.total} ({dept.percentage}%)
                   </span>
                 </div>
@@ -157,20 +157,20 @@ export const AdminDashboard: React.FC = () => {
       </div>
 
       {/* Quick Actions */}
-      <div className="bg-gray-800 p-6 rounded-xl shadow-sm border border-gray-700">
-        <h2 className="text-lg font-semibold text-gray-100 mb-4">Quick Actions</h2>
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Quick Actions</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <button className="p-4 border border-gray-700 rounded-lg hover:bg-gray-700 transition-colors text-left">
-            <h3 className="font-medium text-gray-100 mb-1">Export Audit Log</h3>
-            <p className="text-sm text-gray-400">Download compliance documentation</p>
+          <button className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-700 transition-colors text-left">
+            <h3 className="font-medium text-gray-900 dark:text-gray-100 mb-1">Export Audit Log</h3>
+            <p className="text-sm text-gray-500 dark:text-gray-400">Download compliance documentation</p>
           </button>
-          <button className="p-4 border border-gray-700 rounded-lg hover:bg-gray-700 transition-colors text-left">
-            <h3 className="font-medium text-gray-100 mb-1">Send Reminders</h3>
-            <p className="text-sm text-gray-400">Notify pending training candidates</p>
+          <button className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-700 transition-colors text-left">
+            <h3 className="font-medium text-gray-900 dark:text-gray-100 mb-1">Send Reminders</h3>
+            <p className="text-sm text-gray-500 dark:text-gray-400">Notify pending training candidates</p>
           </button>
-          <button className="p-4 border border-gray-700 rounded-lg hover:bg-gray-700 transition-colors text-left">
-            <h3 className="font-medium text-gray-100 mb-1">Update Modules</h3>
-            <p className="text-sm text-gray-400">Refresh training content</p>
+          <button className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-700 transition-colors text-left">
+            <h3 className="font-medium text-gray-900 dark:text-gray-100 mb-1">Update Modules</h3>
+            <p className="text-sm text-gray-500 dark:text-gray-400">Refresh training content</p>
           </button>
         </div>
       </div>

--- a/src/components/CandidateDashboard.tsx
+++ b/src/components/CandidateDashboard.tsx
@@ -84,16 +84,16 @@ export const CandidateDashboard: React.FC = () => {
         {stats.map((stat, index) => {
           const Icon = stat.icon;
           return (
-            <div key={index} className="bg-gray-800 p-6 rounded-xl shadow-sm border border-gray-700">
+            <div key={index} className="bg-white dark:bg-gray-800 p-6 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
               <div className="flex items-center justify-between mb-4">
                 <div className={`p-2 rounded-lg ${stat.color}`}>
                   <Icon className="h-5 w-5" />
                 </div>
               </div>
               <div>
-                <p className="text-2xl font-bold text-gray-100 mb-1">{stat.value}</p>
-                <p className="text-sm font-medium text-gray-300 mb-1">{stat.title}</p>
-                <p className="text-xs text-gray-400">{stat.description}</p>
+                <p className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-1">{stat.value}</p>
+                <p className="text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">{stat.title}</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">{stat.description}</p>
               </div>
             </div>
           );
@@ -102,10 +102,10 @@ export const CandidateDashboard: React.FC = () => {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Progress Chart */}
-        <div className="lg:col-span-2 bg-gray-800 p-6 rounded-xl shadow-sm border border-gray-700">
+        <div className="lg:col-span-2 bg-white dark:bg-gray-800 p-6 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
           <div className="flex items-center justify-between mb-6">
-            <h2 className="text-lg font-semibold text-gray-100">Learning Progress</h2>
-            <div className="flex items-center gap-2 text-sm text-gray-400">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Learning Progress</h2>
+            <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
               <TrendingUp className="h-4 w-4" />
               <span>2 modules ahead of schedule</span>
             </div>
@@ -120,8 +120,8 @@ export const CandidateDashboard: React.FC = () => {
               return (
                 <div key={module.id} className="space-y-2">
                   <div className="flex items-center justify-between">
-                    <span className="font-medium text-gray-100">{module.title}</span>
-                    <span className="text-sm text-gray-400">
+                    <span className="font-medium text-gray-900 dark:text-gray-100">{module.title}</span>
+                    <span className="text-sm text-gray-500 dark:text-gray-400">
                       {progress?.score ? `${progress.score}%` : `${percentage}%`}
                     </span>
                   </div>
@@ -141,15 +141,15 @@ export const CandidateDashboard: React.FC = () => {
         </div>
 
         {/* Upcoming Deadlines */}
-        <div className="bg-gray-800 p-6 rounded-xl shadow-sm border border-gray-700">
+        <div className="bg-white dark:bg-gray-800 p-6 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
           <div className="flex items-center gap-2 mb-6">
-            <Calendar className="h-5 w-5 text-gray-400" />
-            <h2 className="text-lg font-semibold text-gray-100">Upcoming Deadlines</h2>
+            <Calendar className="h-5 w-5 text-gray-500 dark:text-gray-400" />
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Upcoming Deadlines</h2>
           </div>
           
           <div className="space-y-4">
             {upcomingDeadlines.map((item, index) => (
-              <div key={index} className="p-3 border border-gray-700 rounded-lg">
+              <div key={index} className="p-3 border border-gray-200 dark:border-gray-700 rounded-lg">
                 <div className="flex items-center justify-between mb-2">
                   <span className={`px-2 py-1 rounded-full text-xs font-medium ${
                     item.priority === 'high' ? 'bg-red-100 text-red-800' :
@@ -160,7 +160,7 @@ export const CandidateDashboard: React.FC = () => {
                   </span>
                   <span className="text-xs text-gray-500">{item.deadline}</span>
                 </div>
-                <p className="text-sm font-medium text-gray-100">{item.module}</p>
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{item.module}</p>
               </div>
             ))}
           </div>
@@ -170,7 +170,7 @@ export const CandidateDashboard: React.FC = () => {
       {/* Current Modules */}
       <div>
         <div className="flex items-center justify-between mb-6">
-          <h2 className="text-lg font-semibold text-gray-100">Available Modules</h2>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Available Modules</h2>
           <button className="text-blue-600 hover:text-blue-700 text-sm font-medium">
             View All Modules
           </button>

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -20,18 +20,18 @@ export const LoginForm: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-blue-900 flex items-center justify-center p-4">
-      <div className="bg-gray-800 border border-gray-700 rounded-2xl shadow-2xl w-full max-w-md p-8">
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-2xl w-full max-w-md p-8">
         <div className="text-center mb-8">
           <div className="inline-flex items-center justify-center w-16 h-16 bg-blue-900 rounded-full mb-4">
             <Truck className="h-8 w-8 text-blue-600" />
           </div>
-          <h1 className="text-2xl font-bold text-gray-100">LÍNEA EDUCATRACK</h1>
-          <p className="text-gray-400 mt-2">Logistics Training Platform</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">LÍNEA EDUCATRACK</h1>
+          <p className="text-gray-500 dark:text-gray-400 mt-2">Logistics Training Platform</p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-300 mb-2">
+            <label htmlFor="email" className="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-2">
               Email Address
             </label>
             <input
@@ -39,14 +39,14 @@ export const LoginForm: React.FC = () => {
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full px-4 py-3 bg-gray-700 border border-gray-600 text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+              className="w-full px-4 py-3 bg-gray-200 dark:bg-gray-700 border border-gray-600 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
               placeholder="Enter your email"
               required
             />
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-2">
+            <label htmlFor="password" className="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-2">
               Password
             </label>
             <input
@@ -54,7 +54,7 @@ export const LoginForm: React.FC = () => {
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full px-4 py-3 bg-gray-700 border border-gray-600 text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+              className="w-full px-4 py-3 bg-gray-200 dark:bg-gray-700 border border-gray-600 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
               placeholder="Enter your password"
               required
             />

--- a/src/components/ModuleCard.tsx
+++ b/src/components/ModuleCard.tsx
@@ -16,8 +16,8 @@ export const ModuleCard: React.FC<ModuleCardProps> = ({
   disabled = false 
 }) => {
   const getStatusColor = () => {
-    if (disabled) return 'bg-gray-800 border-gray-700';
-    if (!progress) return 'bg-gray-800 border-gray-700 hover:border-blue-500';
+    if (disabled) return 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700';
+    if (!progress) return 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 hover:border-blue-500';
     
     switch (progress.status) {
       case 'completed':
@@ -27,12 +27,12 @@ export const ModuleCard: React.FC<ModuleCardProps> = ({
       case 'failed':
         return 'bg-red-900/30 border-red-700';
       default:
-        return 'bg-gray-800 border-gray-700 hover:border-blue-500';
+        return 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 hover:border-blue-500';
     }
   };
 
   const getStatusIcon = () => {
-    if (disabled) return <Lock className="h-5 w-5 text-gray-400" />;
+    if (disabled) return <Lock className="h-5 w-5 text-gray-500 dark:text-gray-400" />;
     if (!progress) return <PlayCircle className="h-5 w-5 text-blue-500" />;
     
     switch (progress.status) {
@@ -64,8 +64,8 @@ export const ModuleCard: React.FC<ModuleCardProps> = ({
     <div className={`rounded-xl border-2 p-6 transition-all duration-200 ${getStatusColor()} ${!disabled ? 'hover:shadow-lg cursor-pointer' : 'cursor-not-allowed'}`}>
       <div className="flex items-start justify-between mb-4">
         <div className="flex-1">
-          <h3 className="font-semibold text-gray-100 mb-2">{module.title}</h3>
-          <p className="text-sm text-gray-400 line-clamp-2">{module.description}</p>
+          <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-2">{module.title}</h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400 line-clamp-2">{module.description}</p>
         </div>
         <div className="ml-4">
           {getStatusIcon()}
@@ -84,7 +84,7 @@ export const ModuleCard: React.FC<ModuleCardProps> = ({
         )}
       </div>
 
-      <div className="flex items-center justify-between text-sm text-gray-400 mb-4">
+      <div className="flex items-center justify-between text-sm text-gray-500 dark:text-gray-400 mb-4">
         <div className="flex items-center gap-1">
           <Clock className="h-4 w-4" />
           <span>{module.duration} min</span>
@@ -92,7 +92,7 @@ export const ModuleCard: React.FC<ModuleCardProps> = ({
         {progress && (
           <div className="flex items-center gap-2">
             {progress.score && (
-              <span className="font-medium text-gray-300">Score: {progress.score}%</span>
+              <span className="font-medium text-gray-600 dark:text-gray-300">Score: {progress.score}%</span>
             )}
             <span>Attempts: {progress.attempts}</span>
           </div>
@@ -100,15 +100,15 @@ export const ModuleCard: React.FC<ModuleCardProps> = ({
       </div>
 
       <div className="space-y-2 mb-4">
-        <h4 className="text-xs font-medium text-gray-300 uppercase tracking-wide">Topics Covered</h4>
+        <h4 className="text-xs font-medium text-gray-600 dark:text-gray-300 uppercase tracking-wide">Topics Covered</h4>
         <div className="flex flex-wrap gap-1">
           {module.topics.slice(0, 3).map((topic, index) => (
-            <span key={index} className="px-2 py-1 bg-gray-700 text-xs text-gray-300 rounded">
+            <span key={index} className="px-2 py-1 bg-gray-200 dark:bg-gray-700 text-xs text-gray-600 dark:text-gray-300 rounded">
               {topic}
             </span>
           ))}
           {module.topics.length > 3 && (
-            <span className="px-2 py-1 bg-gray-700 text-xs text-gray-300 rounded">
+            <span className="px-2 py-1 bg-gray-200 dark:bg-gray-700 text-xs text-gray-600 dark:text-gray-300 rounded">
               +{module.topics.length - 3} more
             </span>
           )}
@@ -120,7 +120,7 @@ export const ModuleCard: React.FC<ModuleCardProps> = ({
         disabled={disabled}
         className={`w-full py-2 px-4 rounded-lg font-medium text-sm transition-colors ${
           disabled
-            ? 'bg-gray-700 text-gray-500 cursor-not-allowed'
+            ? 'bg-gray-200 dark:bg-gray-700 text-gray-500 cursor-not-allowed'
             : progress?.status === 'completed'
             ? 'bg-green-600 hover:bg-green-700 text-white'
             : 'bg-blue-600 hover:bg-blue-700 text-white'

--- a/src/components/ModulesView.tsx
+++ b/src/components/ModulesView.tsx
@@ -62,10 +62,10 @@ export const ModulesView: React.FC = () => {
     <div className="space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold text-gray-100 mb-2">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">
           {user?.role === 'admin' ? 'Module Management' : 'My Training Modules'}
         </h1>
-        <p className="text-gray-400">
+        <p className="text-gray-500 dark:text-gray-400 dark:text-gray-400">
           {user?.role === 'admin' 
             ? 'Manage and monitor all training modules'
             : 'Complete your logistics training certification'
@@ -76,49 +76,49 @@ export const ModulesView: React.FC = () => {
       {/* Stats */}
       {user?.role === 'candidate' && (
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <div className="bg-gray-800 p-4 rounded-lg border border-gray-700">
+          <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
             <div className="flex items-center gap-2 mb-2">
               <BookOpen className="h-4 w-4 text-blue-600" />
-              <span className="text-sm font-medium text-gray-400">Total Modules</span>
+              <span className="text-sm font-medium text-gray-500 dark:text-gray-400 dark:text-gray-400">Total Modules</span>
             </div>
-            <p className="text-2xl font-bold text-gray-100">{stats.total}</p>
+            <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">{stats.total}</p>
           </div>
-          <div className="bg-gray-800 p-4 rounded-lg border border-gray-700">
+          <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
             <div className="flex items-center gap-2 mb-2">
               <Award className="h-4 w-4 text-green-600" />
-              <span className="text-sm font-medium text-gray-400">Completed</span>
+              <span className="text-sm font-medium text-gray-500 dark:text-gray-400 dark:text-gray-400">Completed</span>
             </div>
             <p className="text-2xl font-bold text-green-600">{stats.completed}</p>
           </div>
-          <div className="bg-gray-800 p-4 rounded-lg border border-gray-700">
+          <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
             <div className="flex items-center gap-2 mb-2">
               <Clock className="h-4 w-4 text-blue-600" />
-              <span className="text-sm font-medium text-gray-400">In Progress</span>
+              <span className="text-sm font-medium text-gray-500 dark:text-gray-400 dark:text-gray-400">In Progress</span>
             </div>
             <p className="text-2xl font-bold text-blue-600">{stats.inProgress}</p>
           </div>
-          <div className="bg-gray-800 p-4 rounded-lg border border-gray-700">
+          <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
             <div className="flex items-center gap-2 mb-2">
-              <BookOpen className="h-4 w-4 text-gray-400" />
-              <span className="text-sm font-medium text-gray-400">Not Started</span>
+              <BookOpen className="h-4 w-4 text-gray-500 dark:text-gray-400 dark:text-gray-400" />
+              <span className="text-sm font-medium text-gray-500 dark:text-gray-400 dark:text-gray-400">Not Started</span>
             </div>
-            <p className="text-2xl font-bold text-gray-400">{stats.notStarted}</p>
+            <p className="text-2xl font-bold text-gray-500 dark:text-gray-400 dark:text-gray-400">{stats.notStarted}</p>
           </div>
         </div>
       )}
 
       {/* Filters */}
-      <div className="bg-gray-800 p-4 rounded-lg border border-gray-700">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
         <div className="flex flex-col md:flex-row gap-4">
           <div className="flex-1">
             <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-500" />
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-500 dark:text-gray-400" />
               <input
                 type="text"
                 placeholder="Search modules..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                className="w-full pl-10 pr-4 py-2 bg-gray-700 border border-gray-600 text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full pl-10 pr-4 py-2 bg-gray-200 dark:bg-gray-700 border border-gray-600 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               />
             </div>
           </div>
@@ -127,7 +127,7 @@ export const ModulesView: React.FC = () => {
             <select
               value={selectedDifficulty}
               onChange={(e) => setSelectedDifficulty(e.target.value)}
-              className="px-3 py-2 bg-gray-700 border border-gray-600 text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="px-3 py-2 bg-gray-200 dark:bg-gray-700 border border-gray-600 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             >
               <option value="all">All Difficulties</option>
               <option value="Beginner">Beginner</option>
@@ -139,7 +139,7 @@ export const ModulesView: React.FC = () => {
               <select
                 value={selectedStatus}
                 onChange={(e) => setSelectedStatus(e.target.value)}
-                className="px-3 py-2 bg-gray-700 border border-gray-600 text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="px-3 py-2 bg-gray-200 dark:bg-gray-700 border border-gray-600 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               >
                 <option value="all">All Status</option>
                 <option value="not_started">Not Started</option>
@@ -167,9 +167,9 @@ export const ModulesView: React.FC = () => {
 
       {filteredModules.length === 0 && (
         <div className="text-center py-12">
-          <Filter className="h-12 w-12 text-gray-500 mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-gray-100 mb-2">No modules found</h3>
-          <p className="text-gray-400">Try adjusting your search criteria</p>
+          <Filter className="h-12 w-12 text-gray-500 dark:text-gray-400 mx-auto mb-4" />
+          <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">No modules found</h3>
+          <p className="text-gray-500 dark:text-gray-400 dark:text-gray-400">Try adjusting your search criteria</p>
         </div>
       )}
     </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -11,6 +11,7 @@ import {
   Bot
 } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
+import { ThemeToggle } from './ThemeToggle';
 
 interface NavigationProps {
   activeTab: string;
@@ -39,17 +40,17 @@ export const Navigation: React.FC<NavigationProps> = ({ activeTab, onTabChange }
   const tabs = user?.role === 'admin' ? adminTabs : candidateTabs;
 
   return (
-    <nav className="bg-gray-800 shadow-sm border-b border-gray-700">
+    <nav className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center gap-8">
             <div className="flex items-center gap-3">
-              <div className="p-2 bg-blue-900 rounded-lg">
+              <div className="p-2 bg-blue-100 dark:bg-blue-900 rounded-lg">
                 <Truck className="h-6 w-6 text-blue-600" />
               </div>
               <div>
-                <h1 className="text-lg font-bold text-gray-100">LÍNEA EDUCATRACK</h1>
-                <p className="text-xs text-gray-400">ISO 9001:2015 Compliant</p>
+                <h1 className="text-lg font-bold text-gray-900 dark:text-gray-100">LÍNEA EDUCATRACK</h1>
+                <p className="text-xs text-gray-500 dark:text-gray-400">ISO 9001:2015 Compliant</p>
               </div>
             </div>
 
@@ -62,8 +63,8 @@ export const Navigation: React.FC<NavigationProps> = ({ activeTab, onTabChange }
                     onClick={() => onTabChange(tab.id)}
                     className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
                       activeTab === tab.id
-                        ? 'bg-blue-900 text-blue-300'
-                        : 'text-gray-300 hover:text-gray-100 hover:bg-gray-700'
+                        ? 'bg-blue-100 text-blue-600 dark:bg-blue-900 dark:text-blue-300'
+                        : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100 dark:text-gray-300 dark:hover:text-gray-100 dark:hover:bg-gray-700'
                     }`}
                   >
                     <Icon className="h-4 w-4" />
@@ -76,17 +77,18 @@ export const Navigation: React.FC<NavigationProps> = ({ activeTab, onTabChange }
 
           <div className="flex items-center gap-4">
             <div className="text-right">
-              <p className="text-sm font-medium text-gray-100">{user?.name}</p>
-              <p className="text-xs text-gray-400 capitalize">{user?.role} • {user?.department || 'General'}</p>
+              <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{user?.name}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 capitalize">{user?.role} • {user?.department || 'General'}</p>
             </div>
-            <div className="w-8 h-8 bg-blue-900 rounded-full flex items-center justify-center">
+            <div className="w-8 h-8 bg-blue-100 dark:bg-blue-900 rounded-full flex items-center justify-center">
               <span className="text-sm font-medium text-blue-600">
                 {user?.name?.charAt(0) || 'U'}
               </span>
             </div>
+            <ThemeToggle />
             <button
               onClick={logout}
-              className="p-2 text-gray-400 hover:text-gray-200 transition-colors"
+              className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors"
               title="Logout"
             >
               <LogOut className="h-4 w-4" />

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from '../hooks/useTheme';
+
+export const ThemeToggle: React.FC = () => {
+  const { theme, setTheme } = useTheme();
+  return (
+    <button
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+      title="Toggle theme"
+    >
+      {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </button>
+  );
+};

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+export const useTheme = () => {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem('educatrack_theme') as 'light' | 'dark' | null;
+      return saved ?? 'light';
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('educatrack_theme', theme);
+  }, [theme]);
+
+  return { theme, setTheme };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -4,10 +4,18 @@
 
 @layer base {
   html {
+    color-scheme: light;
+  }
+
+  html.dark {
     color-scheme: dark;
   }
-  
+
   body {
+    @apply bg-gray-100 text-gray-900;
+  }
+
+  html.dark body {
     @apply bg-gray-900 text-gray-100;
   }
 }


### PR DESCRIPTION
## Summary
- add `useTheme` hook and `ThemeToggle` component
- integrate theme toggle into Navigation
- ensure theme state is loaded in `App`
- update styles for light/dark modes across components
- adjust base styles for theme support

## Testing
- `npm run lint` *(fails: 29 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_688c6b7daffc8329a518107df3b93ba1