### PR TITLE
Add trainer role and basic course builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project is a learning platform built with React and Vite. Authentication and data storage are handled by [Supabase](https://supabase.com/).
 
+## Roles
+
+Users can log in as **admin**, **trainer** or **learner**. Navigation options adapt to the current role. Trainers and admins have access to the new course builder interface.
+
 ## Setup
 
 1. Install dependencies:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@supabase/supabase-js": "^2.53.0",
         "@types/react-router-dom": "^5.3.3",
         "clsx": "^2.1.1",
@@ -363,6 +365,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@supabase/supabase-js": "^2.53.0",
     "@types/react-router-dom": "^5.3.3",
     "clsx": "^2.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,9 @@ import { AuthProvider } from './components/AuthProvider';
 import { LoginForm } from './components/LoginForm';
 import { Navigation } from './components/Navigation';
 import { AdminDashboard } from './components/AdminDashboard';
-import { CandidateDashboard } from './components/CandidateDashboard';
+import { LearnerDashboard } from './components/LearnerDashboard';
+import { TrainerDashboard } from './components/TrainerDashboard';
+import { CourseBuilder } from './components/CourseBuilder';
 import { ModulesView } from './components/ModulesView';
 import { AnalyticsDashboard } from './components/AnalyticsDashboard';
 import { UserManagement } from './components/UserManagement';
@@ -107,6 +109,8 @@ const AppContent: React.FC = () => {
           return <AnalyticsDashboard />;
         case 'ai-config':
           return <AIConfigurationPanel />;
+        case 'builder':
+          return <CourseBuilder />;
         case 'settings':
           return (
             <div className="bg-gray-800 p-8 rounded-lg border border-gray-700">
@@ -117,10 +121,21 @@ const AppContent: React.FC = () => {
         default:
           return <AdminDashboard />;
       }
+    } else if (user.role === 'trainer') {
+      switch (activeTab) {
+        case 'dashboard':
+          return <TrainerDashboard />;
+        case 'modules':
+          return <ModulesView />;
+        case 'builder':
+          return <CourseBuilder />;
+        default:
+          return <TrainerDashboard />;
+      }
     } else {
       switch (activeTab) {
         case 'dashboard':
-          return <CandidateDashboard />;
+          return <LearnerDashboard />;
         case 'modules':
           return <ModulesView />;
         case 'certificates':
@@ -138,7 +153,7 @@ const AppContent: React.FC = () => {
             </div>
           );
         default:
-          return <CandidateDashboard />;
+          return <LearnerDashboard />;
       }
     }
   };

--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -166,7 +166,7 @@ export const AdminDashboard: React.FC = () => {
           </button>
           <button className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-700 transition-colors text-left">
             <h3 className="font-medium text-gray-900 dark:text-gray-100 mb-1">Send Reminders</h3>
-            <p className="text-sm text-gray-500 dark:text-gray-400">Notify pending training candidates</p>
+            <p className="text-sm text-gray-500 dark:text-gray-400">Notify pending training learners</p>
           </button>
           <button className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-700 transition-colors text-left">
             <h3 className="font-medium text-gray-900 dark:text-gray-100 mb-1">Update Modules</h3>

--- a/src/components/CourseBuilder.tsx
+++ b/src/components/CourseBuilder.tsx
@@ -1,0 +1,116 @@
+import React, { useState, useEffect } from 'react';
+import { DndContext, closestCenter } from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { CourseBlock } from '../types';
+import { supabase } from '../supabaseClient';
+
+interface BlockProps {
+  block: CourseBlock;
+}
+
+const BlockItem: React.FC<BlockProps> = ({ block }) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: block.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  } as React.CSSProperties;
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners} className="p-3 mb-2 bg-white border rounded shadow-sm">
+      <strong className="block text-sm">{block.type}</strong>
+      <span className="text-xs text-gray-600">{block.title}</span>
+    </div>
+  );
+};
+
+export const CourseBuilder: React.FC = () => {
+  const [blocks, setBlocks] = useState<CourseBlock[]>([
+    { id: '1', type: 'lesson', title: 'New Lesson' },
+  ]);
+  const [selected, setSelected] = useState<CourseBlock | null>(blocks[0]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (!selected) return;
+      supabase.rpc('save_builder_draft', { data: blocks }).catch(() => {});
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [blocks, selected]);
+
+  const handleDragEnd = (event: any) => {
+    const { active, over } = event;
+    if (active.id !== over.id) {
+      setBlocks((items) => {
+        const oldIndex = items.findIndex((b) => b.id === active.id);
+        const newIndex = items.findIndex((b) => b.id === over.id);
+        return arrayMove(items, oldIndex, newIndex);
+      });
+    }
+  };
+
+  const updateSelected = (field: keyof CourseBlock, value: string) => {
+    if (!selected) return;
+    setBlocks((prev) => prev.map((b) => (b.id === selected.id ? { ...b, [field]: value } : b)));
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="md:col-span-2">
+        <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={blocks} strategy={verticalListSortingStrategy}>
+            {blocks.map((block) => (
+              <div key={block.id} onClick={() => setSelected(block)}>
+                <BlockItem block={block} />
+              </div>
+            ))}
+          </SortableContext>
+        </DndContext>
+        <button
+          className="mt-2 px-4 py-2 bg-blue-600 text-white rounded"
+          onClick={() =>
+            setBlocks((prev) => [
+              ...prev,
+              { id: Date.now().toString(), type: 'lesson', title: 'Untitled' },
+            ])
+          }
+        >
+          Add Block
+        </button>
+      </div>
+      {selected && (
+        <div className="p-4 bg-gray-800 text-gray-100 rounded">
+          <h3 className="font-semibold mb-2">Block Properties</h3>
+          <div className="space-y-2">
+            <input
+              value={selected.title}
+              onChange={(e) => updateSelected('title', e.target.value)}
+              className="w-full px-2 py-1 text-black rounded"
+            />
+            <input
+              value={selected.description || ''}
+              onChange={(e) => updateSelected('description', e.target.value)}
+              placeholder="Description"
+              className="w-full px-2 py-1 text-black rounded"
+            />
+            <input
+              value={selected.resource || ''}
+              onChange={(e) => updateSelected('resource', e.target.value)}
+              placeholder="Resource URL"
+              className="w-full px-2 py-1 text-black rounded"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/LearnerDashboard.tsx
+++ b/src/components/LearnerDashboard.tsx
@@ -3,7 +3,7 @@ import { BookOpen, Award, Clock, TrendingUp, Target, Calendar } from 'lucide-rea
 import { ModuleCard } from './ModuleCard';
 import { modules } from '../data/modules';
 
-export const CandidateDashboard: React.FC = () => {
+export const LearnerDashboard: React.FC = () => {
   // Mock progress data
   const userProgress = [
     { userId: '2', moduleId: 'basic-transport', status: 'completed' as const, score: 92, timeSpent: 45, attempts: 1, completedAt: new Date('2024-12-15') },

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -85,7 +85,8 @@ export const LoginForm: React.FC = () => {
           <h3 className="font-medium text-blue-300 mb-2">Demo Credentials:</h3>
           <div className="text-sm text-blue-400 space-y-1">
             <p><strong>Admin:</strong> admin@lineaeducatrack.com / demo123</p>
-            <p><strong>Candidate:</strong> candidate@lineaeducatrack.com / demo123</p>
+            <p><strong>Trainer:</strong> trainer@lineaeducatrack.com / demo123</p>
+            <p><strong>Learner:</strong> learner@lineaeducatrack.com / demo123</p>
           </div>
         </div>
       </div>

--- a/src/components/ModulesView.tsx
+++ b/src/components/ModulesView.tsx
@@ -74,7 +74,7 @@ export const ModulesView: React.FC = () => {
       </div>
 
       {/* Stats */}
-      {user?.role === 'candidate' && (
+      {user?.role === 'learner' && (
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
             <div className="flex items-center gap-2 mb-2">
@@ -135,7 +135,7 @@ export const ModulesView: React.FC = () => {
               <option value="Advanced">Advanced</option>
             </select>
 
-            {user?.role === 'candidate' && (
+            {user?.role === 'learner' && (
               <select
                 value={selectedStatus}
                 onChange={(e) => setSelectedStatus(e.target.value)}
@@ -158,9 +158,9 @@ export const ModulesView: React.FC = () => {
           <ModuleCard
             key={module.id}
             module={module}
-            progress={user?.role === 'candidate' ? getModuleProgress(module.id) : undefined}
+            progress={user?.role === 'learner' ? getModuleProgress(module.id) : undefined}
             onStart={handleStartModule}
-            disabled={user?.role === 'candidate' ? isModuleDisabled(module) : false}
+            disabled={user?.role === 'learner' ? isModuleDisabled(module) : false}
           />
         ))}
       </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -8,7 +8,8 @@ import {
   BarChart3,
   LogOut,
   Truck,
-  Bot
+  Bot,
+  LayoutList
 } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 import { ThemeToggle } from './ThemeToggle';
@@ -30,14 +31,24 @@ export const Navigation: React.FC<NavigationProps> = ({ activeTab, onTabChange }
     { id: 'settings', label: 'Settings', icon: Settings }
   ];
 
-  const candidateTabs = [
+  const learnerTabs = [
     { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { id: 'modules', label: 'My Modules', icon: BookOpen },
     { id: 'certificates', label: 'Certificates', icon: Award },
     { id: 'profile', label: 'Profile', icon: Settings }
   ];
 
-  const tabs = user?.role === 'admin' ? adminTabs : candidateTabs;
+  const trainerTabs = [
+    { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
+    { id: 'modules', label: 'Modules', icon: BookOpen },
+    { id: 'builder', label: 'Builder', icon: LayoutList }
+  ];
+
+  const tabs = user?.role === 'admin'
+    ? adminTabs
+    : user?.role === 'trainer'
+    ? trainerTabs
+    : learnerTabs;
 
   return (
     <nav className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">

--- a/src/components/TrainerDashboard.tsx
+++ b/src/components/TrainerDashboard.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export const TrainerDashboard: React.FC = () => {
+  return (
+    <div className="p-6 bg-gray-800 text-gray-100 rounded-lg border border-gray-700">
+      <h2 className="text-xl font-semibold mb-2">Trainer Dashboard</h2>
+      <p className="text-gray-400">Tools for managing courses will appear here.</p>
+    </div>
+  );
+};

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -19,7 +19,7 @@ export const UserManagement: React.FC = () => {
       id: '2',
       email: 'juan.perez@lineaeducatrack.com',
       name: 'Juan Pérez',
-      role: 'candidate',
+      role: 'learner',
       department: 'Trucking',
       createdAt: new Date('2024-01-15'),
       lastLogin: new Date('2024-12-15'),
@@ -30,7 +30,7 @@ export const UserManagement: React.FC = () => {
       id: '3',
       email: 'maria.garcia@lineaeducatrack.com',
       name: 'María García',
-      role: 'candidate',
+      role: 'learner',
       department: 'Frigo',
       createdAt: new Date('2024-02-01'),
       lastLogin: new Date('2024-12-14'),
@@ -41,7 +41,7 @@ export const UserManagement: React.FC = () => {
       id: '4',
       email: 'carlos.lopez@lineaeducatrack.com',
       name: 'Carlos López',
-      role: 'candidate',
+      role: 'learner',
       department: 'Customs',
       createdAt: new Date('2024-02-15'),
       lastLogin: new Date('2024-12-10'),
@@ -93,7 +93,7 @@ export const UserManagement: React.FC = () => {
     const [formData, setFormData] = useState({
       name: user?.name || '',
       email: user?.email || '',
-      role: user?.role || 'candidate',
+      role: user?.role || 'learner',
       department: user?.department || 'General',
       isActive: user?.isActive ?? true
     });
@@ -153,10 +153,11 @@ export const UserManagement: React.FC = () => {
               </label>
               <select
                 value={formData.role}
-                onChange={(e) => setFormData(prev => ({ ...prev, role: e.target.value as 'admin' | 'candidate' }))}
+                onChange={(e) => setFormData(prev => ({ ...prev, role: e.target.value as 'admin' | 'trainer' | 'learner' }))}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
               >
-                <option value="candidate">Candidato</option>
+                <option value="learner">Learner</option>
+                <option value="trainer">Trainer</option>
                 <option value="admin">Administrador</option>
               </select>
             </div>
@@ -253,7 +254,8 @@ export const UserManagement: React.FC = () => {
             >
               <option value="all">Todos los roles</option>
               <option value="admin">Administradores</option>
-              <option value="candidate">Candidatos</option>
+              <option value="trainer">Trainers</option>
+              <option value="learner">Learners</option>
             </select>
 
             <select

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -28,7 +28,7 @@ export const useAuthProvider = () => {
     id: sbUser.id,
     email: sbUser.email ?? '',
     name: (sbUser.user_metadata as any)?.name ?? sbUser.email ?? '',
-    role: (sbUser.user_metadata as any)?.role ?? 'candidate',
+    role: (sbUser.user_metadata as any)?.role ?? 'learner',
     createdAt: new Date(sbUser.created_at),
     isActive: true,
   });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@ export interface User {
   id: string;
   email: string;
   name: string;
-  role: 'admin' | 'candidate';
+  role: 'admin' | 'trainer' | 'learner';
   department?: 'Frigo' | 'Tautliner' | 'Trucking' | 'Customs' | 'General';
   avatar?: string;
   createdAt: Date;
@@ -26,6 +26,14 @@ export interface Module {
   isActive: boolean;
   requiredScore: number;
   maxAttempts: number;
+}
+
+export interface CourseBlock {
+  id: string;
+  type: 'lesson' | 'video' | 'pdf' | 'external' | 'quiz' | 'section';
+  title: string;
+  description?: string;
+  resource?: string;
 }
 
 export interface Progress {


### PR DESCRIPTION
## Summary
- expand `User` role to include trainer and learner
- add CourseBuilder component with drag-and-drop
- add TrainerDashboard and update navigation
- rename CandidateDashboard to LearnerDashboard
- show role-specific tabs and demo credentials
- document roles in README

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c6d465a5c832982863ed816bd7d74