### PR TITLE
Add local progress tracking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { useAuth } from './hooks/useAuth';
 import { modules as staticModules } from './data/modules';
 import { useTheme } from './hooks/useTheme';
 import { useModules } from './hooks/useModules';
+import { ProgressProvider } from './hooks/useProgress';
 
 const AppContent: React.FC = () => {
   useTheme();
@@ -172,7 +173,9 @@ const AppContent: React.FC = () => {
 function App() {
   return (
     <AuthProvider>
-      <AppContent />
+      <ProgressProvider>
+        <AppContent />
+      </ProgressProvider>
     </AuthProvider>
   );
 }

--- a/src/components/LearnerDashboard.tsx
+++ b/src/components/LearnerDashboard.tsx
@@ -2,40 +2,38 @@ import React from 'react';
 import { BookOpen, Award, Clock, TrendingUp, Target, Calendar } from 'lucide-react';
 import { ModuleCard } from './ModuleCard';
 import { modules } from '../data/modules';
+import { useProgress } from '../hooks/useProgress';
+import type { Module } from '../types';
 
 export const LearnerDashboard: React.FC = () => {
-  // Mock progress data
-  const userProgress = [
-    { userId: '2', moduleId: 'basic-transport', status: 'completed' as const, score: 92, timeSpent: 45, attempts: 1, completedAt: new Date('2024-12-15') },
-    { userId: '2', moduleId: 'direct-loads', status: 'completed' as const, score: 88, timeSpent: 58, attempts: 1, completedAt: new Date('2024-12-16') },
-    { userId: '2', moduleId: 'trucking-romper', status: 'in_progress' as const, score: undefined, timeSpent: 35, attempts: 1 },
-  ];
+  const { progress, startModule } = useProgress();
 
+  const completed = progress.filter(p => p.status === 'completed');
   const stats = [
     {
       title: 'Modules Completed',
-      value: '2/8',
-      description: '25% Complete',
+      value: `${completed.length}/${modules.length}`,
+      description: `${Math.round((completed.length / modules.length) * 100) || 0}% Complete`,
       icon: BookOpen,
       color: 'bg-blue-100 text-blue-600'
     },
     {
       title: 'Average Score',
-      value: '90%',
-      description: 'Above target',
+      value: completed.length ? `${Math.round(completed.reduce((a, c) => a + (c.score || 0), 0) / completed.length)}%` : '0%',
+      description: 'Average of passed modules',
       icon: Target,
       color: 'bg-green-100 text-green-600'
     },
     {
       title: 'Time Invested',
-      value: '2.3h',
-      description: 'This week',
+      value: `${(progress.reduce((a, c) => a + c.timeSpent, 0) / 60).toFixed(1)}h`,
+      description: 'Total time',
       icon: Clock,
       color: 'bg-purple-100 text-purple-600'
     },
     {
       title: 'Certificates',
-      value: '2',
+      value: completed.filter(p => p.certificateId).length.toString(),
       description: 'Active certificates',
       icon: Award,
       color: 'bg-yellow-100 text-yellow-600'
@@ -49,17 +47,18 @@ export const LearnerDashboard: React.FC = () => {
   ];
 
   const handleStartModule = (moduleId: string) => {
+    startModule(moduleId);
     console.log('Starting module:', moduleId);
   };
 
   const getModuleProgress = (moduleId: string) => {
-    return userProgress.find(p => p.moduleId === moduleId);
+    return progress.find(p => p.moduleId === moduleId);
   };
 
-  const isModuleDisabled = (module: any) => {
+  const isModuleDisabled = (module: Module) => {
     if (!module.prerequisites?.length) return false;
-    return !module.prerequisites.every(prereq => 
-      userProgress.some(p => p.moduleId === prereq && p.status === 'completed')
+    return !module.prerequisites.every(prereq =>
+      progress.some(p => p.moduleId === prereq && p.status === 'completed')
     );
   };
 

--- a/src/components/ModulesView.tsx
+++ b/src/components/ModulesView.tsx
@@ -4,34 +4,34 @@ import { ModuleCard } from './ModuleCard';
 import { modules as staticModules } from '../data/modules';
 import { useAuth } from '../hooks/useAuth';
 import { useModules } from '../hooks/useModules';
+import { useProgress } from '../hooks/useProgress';
+import type { Module } from '../types';
 
 export const ModulesView: React.FC = () => {
   const { user } = useAuth();
   const { modules } = useModules();
+  const { progress, startModule } = useProgress();
   const allModules = modules.length > 0 ? modules : staticModules;
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedDifficulty, setSelectedDifficulty] = useState<string>('all');
   const [selectedStatus, setSelectedStatus] = useState<string>('all');
 
-  // Mock progress data
-  const userProgress = [
-    { userId: '2', moduleId: 'basic-transport', status: 'completed' as const, score: 92, timeSpent: 45, attempts: 1, completedAt: new Date('2024-12-15') },
-    { userId: '2', moduleId: 'direct-loads', status: 'completed' as const, score: 88, timeSpent: 58, attempts: 1, completedAt: new Date('2024-12-16') },
-    { userId: '2', moduleId: 'trucking-romper', status: 'in_progress' as const, score: undefined, timeSpent: 35, attempts: 1 },
-  ];
 
   const handleStartModule = (moduleId: string) => {
+    if (user?.role === 'learner') {
+      startModule(moduleId);
+    }
     console.log('Starting module:', moduleId);
   };
 
   const getModuleProgress = (moduleId: string) => {
-    return userProgress.find(p => p.moduleId === moduleId);
+    return progress.find(p => p.moduleId === moduleId);
   };
 
-  const isModuleDisabled = (module: any) => {
+  const isModuleDisabled = (module: Module) => {
     if (!module.prerequisites?.length) return false;
     return !module.prerequisites.every(prereq => 
-      userProgress.some(p => p.moduleId === prereq && p.status === 'completed')
+      progress.some(p => p.moduleId === prereq && p.status === 'completed')
     );
   };
 
@@ -53,9 +53,9 @@ export const ModulesView: React.FC = () => {
 
   const stats = {
     total: allModules.length,
-    completed: userProgress.filter(p => p.status === 'completed').length,
-    inProgress: userProgress.filter(p => p.status === 'in_progress').length,
-    notStarted: allModules.length - userProgress.length
+    completed: progress.filter(p => p.status === 'completed').length,
+    inProgress: progress.filter(p => p.status === 'in_progress').length,
+    notStarted: allModules.length - progress.length
   };
 
   return (

--- a/src/hooks/useProgress.tsx
+++ b/src/hooks/useProgress.tsx
@@ -1,0 +1,73 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import type { Progress } from '../types';
+import { useAuth } from './useAuth';
+
+interface ProgressContextType {
+  progress: Progress[];
+  startModule: (moduleId: string) => void;
+  completeModule: (moduleId: string, score: number) => void;
+}
+
+const ProgressContext = createContext<ProgressContextType | undefined>(undefined);
+
+export const ProgressProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { user } = useAuth();
+  const [progress, setProgress] = useState<Progress[]>([]);
+
+  useEffect(() => {
+    if (user) {
+      const stored = localStorage.getItem(`educatrack_progress_${user.id}`);
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored) as Progress[];
+          setProgress(parsed.map(p => ({ ...p, lastActivity: new Date(p.lastActivity), completedAt: p.completedAt ? new Date(p.completedAt) : undefined }))); 
+        } catch {
+          setProgress([]);
+        }
+      }
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (user) {
+      localStorage.setItem(`educatrack_progress_${user.id}`, JSON.stringify(progress));
+    }
+  }, [progress, user]);
+
+  const startModule = (moduleId: string) => {
+    if (!user) return;
+    setProgress(prev => {
+      const existing = prev.find(p => p.moduleId === moduleId);
+      if (existing) {
+        return prev.map(p => p.moduleId === moduleId ? { ...p, status: 'in_progress', attempts: p.attempts + 1, lastActivity: new Date() } : p);
+      }
+      const newProgress: Progress = {
+        userId: user.id,
+        moduleId,
+        status: 'in_progress',
+        attempts: 1,
+        timeSpent: 0,
+        timeOnPage: 0,
+        interactions: 0,
+        lastActivity: new Date()
+      };
+      return [...prev, newProgress];
+    });
+  };
+
+  const completeModule = (moduleId: string, score: number) => {
+    setProgress(prev => prev.map(p => p.moduleId === moduleId ? { ...p, status: score >= 70 ? 'completed' : 'failed', score, completedAt: new Date(), lastActivity: new Date() } : p));
+  };
+
+  return (
+    <ProgressContext.Provider value={{ progress, startModule, completeModule }}>
+      {children}
+    </ProgressContext.Provider>
+  );
+};
+
+export const useProgress = () => {
+  const ctx = useContext(ProgressContext);
+  if (!ctx) throw new Error('useProgress must be used within ProgressProvider');
+  return ctx;
+};


### PR DESCRIPTION
## Summary
- add `useProgress` hook and provider for storing module progress in localStorage
- wire progress provider into `App`
- use progress data in `ModulesView` and `LearnerDashboard`

## Testing
- `npm run lint` *(fails: 29 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c6f59d20c8329ba54c1856d1d830b