### PR TITLE
Improve auth persistence

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -15,9 +15,6 @@ export const LoginForm: React.FC = () => {
     const success = await login(identifier, password);
     if (!success) {
       setError('Invalid credentials');
-    } else {
-      // Reload to render the authenticated dashboard
-      window.location.href = '/';
     }
   };
 


### PR DESCRIPTION
## Summary
- fetch user profile from Firestore to get role and department
- persist user info in localStorage on load and login
- remove reload from login form

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688cfbd0261c8329aba8edaddf124f57