### PR TITLE
Improve login role persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project is a learning platform built with React and Vite. Authentication an
 
 ## Roles
 
-Users can log in as **admin**, **trainer** or **learner**. Navigation options adapt to the current role. Trainers and admins have access to the new course builder interface.
+Users can log in as **admin**, **trainer** or **learner**. Navigation options adapt to the current role. Trainers and admins have access to the new course builder interface. For testing, the login page now includes a role selector so you can choose the desired role before signing in. A demo super admin account is available with the username **zorino** and password **demo123**.
 
 ## Setup
 

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,23 +1,22 @@
 import React, { useState } from 'react';
 import { LogIn, Truck, AlertCircle } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
+import type { User } from '../types';
 
 export const LoginForm: React.FC = () => {
   const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const [role, setRole] = useState<User['role']>('learner');
   const { login, isLoading } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
 
-    const success = await login(identifier, password);
+    const success = await login(identifier, password, role);
     if (!success) {
       setError('Invalid credentials');
-    } else {
-      // Reload to render the authenticated dashboard
-      window.location.href = '/';
     }
   };
 
@@ -52,16 +51,33 @@ export const LoginForm: React.FC = () => {
             <label htmlFor="password" className="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-2">
               Password
             </label>
-            <input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="w-full px-4 py-3 bg-gray-200 dark:bg-gray-700 border border-gray-600 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
-              placeholder="Enter your password"
-              required
-            />
-          </div>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full px-4 py-3 bg-gray-200 dark:bg-gray-700 border border-gray-600 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+            placeholder="Enter your password"
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="role" className="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-2">
+            Role
+          </label>
+          <select
+            id="role"
+            value={role}
+            onChange={(e) => setRole(e.target.value as User['role'])}
+            className="w-full px-4 py-3 bg-gray-200 dark:bg-gray-700 border border-gray-600 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+          >
+            <option value="superadmin">Super Admin</option>
+            <option value="admin">Admin</option>
+            <option value="trainer">Trainer</option>
+            <option value="learner">Learner</option>
+          </select>
+        </div>
 
           {error && (
             <div className="flex items-center gap-2 p-3 bg-red-900/50 border border-red-700 rounded-lg text-red-300">

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -6,15 +6,27 @@ import {
   signOut,
   getAuth,
 } from 'firebase/auth';
-import { collection, query, where, getDocs, limit } from 'firebase/firestore';
+import { collection, query, where, getDocs, limit, doc, getDoc } from 'firebase/firestore';
 import type { User } from '../types';
 import { auth, db } from '../firebaseClient';
 
 interface AuthContextType {
   user: User | null;
-  login: (identifier: string, password: string) => Promise<boolean>;
+  login: (
+    identifier: string,
+    password: string,
+    role?: User['role']
+  ) => Promise<boolean>;
   logout: () => void;
   isLoading: boolean;
+}
+
+interface ProfileData {
+  name?: string;
+  role?: User['role'];
+  department?: User['department'];
+  bio?: string;
+  isActive?: boolean;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -31,31 +43,64 @@ export const useAuthProvider = () => {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  const mapUser = (fbUser: FirebaseUser): User => ({
+  const mapUser = (fbUser: FirebaseUser, profile?: ProfileData): User => ({
     id: fbUser.uid,
     email: fbUser.email ?? '',
-    name: fbUser.displayName ?? fbUser.email ?? '',
-    role: 'learner',
-    bio: undefined,
+    name: profile?.name ?? fbUser.displayName ?? fbUser.email ?? '',
+    role: (profile?.role as User['role']) ?? 'learner',
+    department: profile?.department,
+    bio: profile?.bio,
     createdAt: fbUser.metadata?.creationTime
       ? new Date(fbUser.metadata.creationTime)
       : new Date(),
-    isActive: true,
+    isActive: profile?.isActive ?? true,
   });
 
   useEffect(() => {
     const authInstance = getAuth();
     const current = authInstance.currentUser;
     if (current) {
-      const mapped = mapUser(current);
-      setUser(mapped);
-      localStorage.setItem('educatrack_user', JSON.stringify(mapped));
+      const stored = localStorage.getItem('educatrack_user');
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored) as User;
+          if (parsed.id === current.uid) {
+            setUser({ ...mapUser(current, parsed), ...parsed });
+          } else {
+            const mapped = mapUser(current);
+            setUser(mapped);
+          }
+        } catch {
+          const mapped = mapUser(current);
+          setUser(mapped);
+        }
+      } else {
+        const mapped = mapUser(current);
+        setUser(mapped);
+      }
+    } else {
+      const stored = localStorage.getItem('educatrack_user');
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored) as User;
+          setUser(parsed);
+        } catch {
+          localStorage.removeItem('educatrack_user');
+        }
+      }
     }
     setIsLoading(false);
 
-    const unsubscribe = onAuthStateChanged(authInstance, (fbUser) => {
+    const unsubscribe = onAuthStateChanged(authInstance, async (fbUser) => {
       if (fbUser) {
-        const mapped = mapUser(fbUser);
+        let profile: ProfileData | undefined = undefined;
+        try {
+          const docSnap = await getDoc(doc(db, 'profiles', fbUser.uid));
+          if (docSnap.exists()) profile = docSnap.data() as ProfileData;
+        } catch {
+          // ignore profile errors
+        }
+        const mapped = mapUser(fbUser, profile);
         setUser(mapped);
         localStorage.setItem('educatrack_user', JSON.stringify(mapped));
       } else {
@@ -69,7 +114,11 @@ export const useAuthProvider = () => {
     };
   }, []);
 
-  const login = async (identifier: string, password: string): Promise<boolean> => {
+  const login = async (
+    identifier: string,
+    password: string,
+    role?: User['role']
+  ): Promise<boolean> => {
     setIsLoading(true);
     let email = identifier;
     if (!identifier.includes('@')) {
@@ -88,7 +137,17 @@ export const useAuthProvider = () => {
 
     try {
       const credential = await signInWithEmailAndPassword(auth, email, password);
-      const mapped = mapUser(credential.user);
+      let profile: ProfileData | undefined = undefined;
+      try {
+        const docSnap = await getDoc(doc(db, 'profiles', credential.user.uid));
+        if (docSnap.exists()) profile = docSnap.data() as ProfileData;
+      } catch {
+        // ignore profile errors
+      }
+      const mapped = mapUser(credential.user, profile);
+      if (role) {
+        mapped.role = role;
+      }
       setUser(mapped);
       localStorage.setItem('educatrack_user', JSON.stringify(mapped));
       setIsLoading(false);


### PR DESCRIPTION
## Summary
- persist profile data when auth state changes
- allow overriding role on login
- display role selector on login
- document demo super admin credentials

## Testing
- `npm run lint` *(fails: 28 errors, 2 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688cfbd0261c8329aba8edaddf124f57