### PR TITLE
Improve module loading robustness

### DIFF
--- a/src/hooks/useModules.ts
+++ b/src/hooks/useModules.ts
@@ -9,15 +9,20 @@ export const useModules = () => {
 
   useEffect(() => {
     const load = async () => {
-      const snapshot = await getDocs(collection(db, 'modules'));
-      setModules(
-        snapshot.docs.map((d) => ({
-          id: d.id,
-          ...(d.data() as any),
-          lastUpdated: new Date((d.data() as any).lastUpdated),
-        }))
-      );
-      setLoading(false);
+      try {
+        const snapshot = await getDocs(collection(db, 'modules'));
+        setModules(
+          snapshot.docs.map((d) => ({
+            id: d.id,
+            ...(d.data() as Module),
+            lastUpdated: new Date((d.data() as { lastUpdated: string }).lastUpdated),
+          }))
+        );
+      } catch (err) {
+        console.error('Failed to load modules', err);
+      } finally {
+        setLoading(false);
+      }
     };
 
     load();


### PR DESCRIPTION
## Summary
- handle errors when loading modules from Firestore

## Testing
- `npm run build`
- `npm run lint` *(fails: 26 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688d06f7f8cc8329843178c9f431de0a